### PR TITLE
ConfigCenter: set minimum blur value to 0 of media artwork

### DIFF
--- a/res/xml/config_center_lockscreen.xml
+++ b/res/xml/config_center_lockscreen.xml
@@ -44,7 +44,7 @@
             android:key="lockscreen_media_blur"
             android:title="@string/lockscreen_media_blur_title"
             android:max="100"
-            settings:min="5"
+            settings:min="0"
             settings:units="%"
             settings:interval="5"
             android:defaultValue="100"


### PR DESCRIPTION
Media artwork blur value ranges from 5-100%, we need 0 also please.